### PR TITLE
run action only if pull request is merged

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches: [ "**" ]
     paths-ignore:
-      - '**/*.md'  
-  pull_request:
+      - '**/*.md'
+  pull_request_review:
+    types:
+      - submitted
     branches: [ "**" ]
   
 


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_review
should also be pushed to main branch
also you can remain event pull_request and add check if_merged in jobs but why?