### PR TITLE
feat: Send APK's to Telegram 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Send APK to Telegram
         if: success()
         run: |
-          curl -X POST "https://api.telegram.org/bot7611011157:AAGexJbzGNIbrbnfTSdF5QyH5YajeqMoZeo/sendDocument" \
+          curl -X POST ${{ secrets.TELEGRAM_URL }} \
             -F chat_id="-1002408175863" \
             -F message_thread_id="582" \
             -F document=@"app/karbon.apk"
@@ -89,11 +89,3 @@ jobs:
         with:
           name: Karbon-Debug
           path: app/karbon-debug.apk
-      
-      - name: Send APK to Telegram
-        if: success()
-        run: |
-          curl -X POST "https://api.telegram.org/bot7611011157:AAGexJbzGNIbrbnfTSdF5QyH5YajeqMoZeo/sendDocument" \
-            -F chat_id="-1002408175863" \
-            -F message_thread_id="582" \
-            -F document=@"app/karbon-debug.apk"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -50,7 +50,15 @@ jobs:
 
       - name: Delete xed.keystore and signing.properties
         run: rm /tmp/xed.keystore /tmp/signing.properties
-        
+      
+      - name: Send APK to Telegram without text
+        if: success()
+        run: |
+          curl -X POST "https://api.telegram.org/bot7611011157:AAGexJbzGNIbrbnfTSdF5QyH5YajeqMoZeo/sendDocument" \
+            -F chat_id="-1002408175863" \
+            -F message_thread_id="582" \
+            -F document=@"app/karbon.apk"
+            
   build_debug_apk:
     name: Build Debug
     runs-on: ubuntu-latest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           KEYSTORE_FILE: /tmp/xed.keystore
           SIGNING_PROPERTIES_FILE: /tmp/signing.properties
-        continue-on-error: true 
+        continue-on-error: true
 
       - name: Archive APK
         uses: actions/upload-artifact@v4
@@ -50,15 +50,15 @@ jobs:
 
       - name: Delete xed.keystore and signing.properties
         run: rm /tmp/xed.keystore /tmp/signing.properties
-      
+
       - name: Send APK to Telegram
         if: success()
         run: |
-          curl -X POST ${{ secrets.TELEGRAM_URL }} \
+          curl -X POST "${{ secrets.TELEGRAM_URL }}" \
             -F chat_id="-1002408175863" \
             -F message_thread_id="582" \
             -F document=@"app/karbon.apk"
-            
+
   build_debug_apk:
     name: Build Debug
     runs-on: ubuntu-latest
@@ -79,7 +79,7 @@ jobs:
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
-      
+
       - name: Build with Gradle
         id: gradle_build_debug
         run: ./gradlew assembleDebug && mv app/build/outputs/apk/debug/*apk app/karbon-debug.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Delete xed.keystore and signing.properties
         run: rm /tmp/xed.keystore /tmp/signing.properties
       
-      - name: Send APK to Telegram without text
+      - name: Send APK to Telegram
         if: success()
         run: |
           curl -X POST "https://api.telegram.org/bot7611011157:AAGexJbzGNIbrbnfTSdF5QyH5YajeqMoZeo/sendDocument" \
@@ -89,3 +89,11 @@ jobs:
         with:
           name: Karbon-Debug
           path: app/karbon-debug.apk
+      
+      - name: Send APK to Telegram
+        if: success()
+        run: |
+          curl -X POST "https://api.telegram.org/bot7611011157:AAGexJbzGNIbrbnfTSdF5QyH5YajeqMoZeo/sendDocument" \
+            -F chat_id="-1002408175863" \
+            -F message_thread_id="582" \
+            -F document=@"app/karbon-debug.apk"

--- a/app/src/main/java/com/rk/xededitor/pluginClient/ManagePlugins.kt
+++ b/app/src/main/java/com/rk/xededitor/pluginClient/ManagePlugins.kt
@@ -63,6 +63,7 @@ import com.rk.libcommons.LoadingPopup
 import com.rk.xededitor.R
 import com.rk.xededitor.rkUtils
 import com.rk.xededitor.ui.theme.KarbonTheme
+import com.rk.xededitor.BaseActivity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -109,7 +110,7 @@ class PluginModel : ViewModel() {
 }
 
 
-class ManagePlugins : ComponentActivity() {
+class ManagePlugins : BaseActivity() {
   private val model: PluginModel by viewModels()
 
   private val PICK_FILE_REQUEST_CODE = 46547


### PR DESCRIPTION
In this PR I also send the Debug, I don't think this is interesting, if you prefer, remove it.
Also, for better security, put the chat id and bot token in the secrets instead of using them directly in the workflow.